### PR TITLE
fix main.tf permissions for sagemaker:addTag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 **/.idea
 **/.DS_Store
+*.zip
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup

--- a/terraform/infrastructure/terraform.tfvars
+++ b/terraform/infrastructure/terraform.tfvars
@@ -1,6 +1,6 @@
 ## Change project_name to your project name
 project_name = "ml-pipeline-terraform-demo" //put your project name here
-region = "eu-west-1" //change region if desired to deploy in another region
+region = "us-east-1" //change region if desired to deploy in another region
 
 ## Change instance types amd volume size for SageMaker if desired
 training_instance_type = "ml.m5.xlarge"

--- a/terraform/ml-pipeline-module/main.tf
+++ b/terraform/ml-pipeline-module/main.tf
@@ -81,7 +81,8 @@ resource "aws_iam_policy" "sagemaker_policy" {
                       "sagemaker:StopTrainingJob",
                       "sagemaker:createModel",
                       "sagemaker:createEndpointConfig",
-                      "sagemaker:createEndpoint"
+                      "sagemaker:createEndpoint",
+                      "sagemaker:addTags"
                   ],
                   "Resource": [
                    "*"


### PR DESCRIPTION
*Issue: Step Functions failed to build at Create Training Job*

*Description of changes:*
Added "sagemaker:addTags" to permissions list in file: ml-pipeline-module/main.tf for policy to invoke training job.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
