### PR TITLE
Update requirements.txt

### DIFF
--- a/src/container/requirements.txt
+++ b/src/container/requirements.txt
@@ -1,12 +1,12 @@
 # required to serve the model
-flask
-gevent
-gunicorn
+flask==2.2.2
+gevent==22.10.2
+gunicorn==20.1.0
 
 
 # dependencies for the custom model
 boto3
-scikit-learn==0.22.2
-numpy==1.18.5
-scipy==1.5.0
-pandas==1.1.1
+scikit-learn==1.0.2
+numpy==1.21.6
+scipy==1.7.3
+pandas==1.3.5


### PR DESCRIPTION
Current requirements fails to build for numpy.
Using the automated resolver set the pin to these versions.

*Issue #, if available:*

*Description of changes:*
Current dockerfile fails to build due to numpy and scikitlearn versions.
This fix updates that.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
